### PR TITLE
Change gray scale's steps 2 to 4

### DIFF
--- a/vars/general.json
+++ b/vars/general.json
@@ -1,14 +1,13 @@
 {
   "s-color-gray-1": "#f0f0f2",
-  "s-color-gray-2": "#ececf0",
-  "s-color-gray-3": "#e9e9ee",
-  "s-color-gray-4": "#cfcfd6",
+  "s-color-gray-2": "#e3e4e9",
+  "s-color-gray-3": "#d4d6dd",
+  "s-color-gray-4": "#c3c2ca",
   "s-color-gray-5": "#b6b6be",
   "s-color-gray-6": "#92929e",
   "s-color-gray-7": "#6e6e7e",
   "s-color-gray-8": "#393855",
   "s-color-gray-9": "#05032d",
-
   "s-color-primary-1": "#cacbee",
   "s-color-primary-2": "#afb1e5",
   "s-color-primary-3": "#9598dd",
@@ -18,7 +17,6 @@
   "s-color-primary-7": "#272ca9",
   "s-color-primary-8": "#1d2284",
   "s-color-primary-9": "#13175f",
-
   "s-color-secondary-1": "#eee8ca",
   "s-color-secondary-2": "#e5dbaf",
   "s-color-secondary-3": "#ddcf95",
@@ -28,7 +26,6 @@
   "s-color-secondary-7": "#a99127",
   "s-color-secondary-8": "#84711d",
   "s-color-secondary-9": "#5f5013",
-
   "s-color-positive": "#46d38e",
   "s-color-negative": "#e74e4b"
 }


### PR DESCRIPTION
For an unknown reason the gray scale's 2 and 3 look pretty similiar – which is sad. Anja slightly adjusted the values of those steps and also made step 4 fit into the scale. 

For recapitulation: The gray scale palette was defined by us – the Visuals team – but bases on three gray tones defined in the NZZ.ch product (background: s-color-gray-1, author: s-color-gray-7, text: s-color-gray-9) . 

![image](https://user-images.githubusercontent.com/588074/73289362-e18e8800-41fc-11ea-8659-36b840d83571.png)
