### PR TITLE
Removes first and secondary color scales

### DIFF
--- a/scss/general.scss
+++ b/scss/general.scss
@@ -28,34 +28,6 @@
   color: $s-color-gray-9;
 }
 
-.s-color-primary-1 {
-  color: $s-color-primary-1;
-}
-.s-color-primary-2 {
-  color: $s-color-primary-2;
-}
-.s-color-primary-3 {
-  color: $s-color-primary-3;
-}
-.s-color-primary-4 {
-  color: $s-color-primary-4;
-}
-.s-color-primary-5 {
-  color: $s-color-primary-5;
-}
-.s-color-primary-6 {
-  color: $s-color-primary-6;
-}
-.s-color-primary-7 {
-  color: $s-color-primary-7;
-}
-.s-color-primary-8 {
-  color: $s-color-primary-8;
-}
-.s-color-primary-9 {
-  color: $s-color-primary-9;
-}
-
 .s-color-positive {
   color: $s-color-positive;
 }

--- a/vars/general.json
+++ b/vars/general.json
@@ -8,15 +8,6 @@
   "s-color-gray-7": "#6e6e7e",
   "s-color-gray-8": "#393855",
   "s-color-gray-9": "#05032d",
-  "s-color-primary-1": "#cacbee",
-  "s-color-primary-2": "#afb1e5",
-  "s-color-primary-3": "#9598dd",
-  "s-color-primary-4": "#6065cd",
-  "s-color-primary-5": "#2c32bd",
-  "s-color-primary-6": "#292fb3",
-  "s-color-primary-7": "#272ca9",
-  "s-color-primary-8": "#1d2284",
-  "s-color-primary-9": "#13175f",
   "s-color-positive": "#46d38e",
   "s-color-negative": "#e74e4b"
 }


### PR DESCRIPTION
The first and secondary color scale are not actively used anymore and are not documented in the [visuals styleguide](https://nzzdev.github.io/Storytelling-Styleguide/#/colors). I propose to remove them in a next minor or major version of this module.

We do not lose "color quality" by removing them because the first two qualitative color scales of sophie's viz colors are already based on a blueish and a yellowish tone. It would be weird to have two similar scales without a clear documentation when to use which one. The gray scales still includes colors of the NZZ screen / brand colors –  and has a blueish tone as well.
